### PR TITLE
Change size of header tag for correct subsections

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Be sure to have LaTeX ([Windows](http://miktex.org/), [OS
 X](https://tug.org/mactex/), [Linux](http://latex-project.org/)) and Pandoc
 installed.
 
-Pandoc can be installed with Homebrew: `brew install pandoc`.
+On OS X, Pandoc can be installed with Homebrew: `brew install pandoc`.
 
 ## Typeset
 For now there is a simple Bash script to typeset the document. To typeset it,

--- a/dynamic/javascript.md
+++ b/dynamic/javascript.md
@@ -1,4 +1,4 @@
-# JavaScript
+## JavaScript
 JavaScript, also known as ECMAScript (the untrademarked name used for the
 standard), is a dynamic programming language.
 

--- a/dynamic/python.md
+++ b/dynamic/python.md
@@ -1,4 +1,4 @@
-# Python
+## Python
 Python is a widely used general-purpose, high-level programming language.
 
 ```python

--- a/dynamic/ruby.md
+++ b/dynamic/ruby.md
@@ -1,18 +1,18 @@
 \chapter{Dynamic languages}
 
-# Ruby
+## Ruby
 Ruby is a dynamic, reflective, object-oriented, general-purpose programming
 language.
 
-## Code examples
+### Code examples
 
-### Hello World
+#### Hello World
 
 ```ruby
 puts "Hello World!"
 ```
 
-### String interpolation
+#### String interpolation
 
 ```ruby
 var = 3.14159

--- a/functional/fsharp.md
+++ b/functional/fsharp.md
@@ -1,4 +1,4 @@
-# F\#
+## F\#
 F# is a strongly typed, multi-paradigm programming language that encompasses
 functional, imperative, and object-oriented programming techniques.
 

--- a/functional/haskell.md
+++ b/functional/haskell.md
@@ -1,6 +1,6 @@
 \chapter{Functional languages}
 
-# Haskell
+## Haskell
 Haskell is a standardized, general-purpose purely functional programming
 language, with non-strict semantics and strong static typing.
 

--- a/static/csharp.md
+++ b/static/csharp.md
@@ -1,4 +1,4 @@
-# C\#
+## C\#
 C# is a multi-paradigm programming language encompassing strong typing,
 imperative, declarative, functional, generic, object-oriented (class-based), and
 component-oriented programming disciplines.

--- a/static/java.md
+++ b/static/java.md
@@ -1,6 +1,6 @@
 \chapter{Static languages}
 
-# Java
+## Java
 Java is a general-purpose computer programming language that is concurrent,
 class-based, object-oriented, and specifically designed to have as few
 implementation dependencies as possible.


### PR DESCRIPTION
Having an H1 tag (`#`) for the header of the individual sub-chapters meant that they were treated as separate chapters independent of the `\chapter{…}` code.

Changing the title of the sub-chapters to use an H2 (`##`) fixed it.

BTW, thank you for writing this, it's exactly what I needed for my own project!
