### PR TITLE
Fix escaping of # in C#

### DIFF
--- a/report-bib/static/csharp.md
+++ b/report-bib/static/csharp.md
@@ -1,4 +1,4 @@
-## C\#
+## C# #
 C# is a multi-paradigm programming language encompassing strong typing,
 imperative, declarative, functional, generic, object-oriented (class-based), and
 component-oriented programming disciplines.


### PR DESCRIPTION
Any number of # characters immediately before the newline are used to close the heading block and are removed before generating output.  Therefore, you can simply add a space and another # to get the proper "C#" text in the heading.  See http://meta.stackexchange.com/a/260358.